### PR TITLE
Allow using an env var for graphql endpoint

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -4,7 +4,8 @@ module.exports = {
   output: (...messages) => console.log('[BlockIngestor]', ...messages),
   poorMansGraphQL: async (
     query,
-    endpoint = 'http://192.168.0.220:20002/graphql',
+    endpoint = process.env.GraphQLAPIEndpointOutput ||
+      "http://192.168.0.220:20002/graphql",
     /*
      * @NOTE This is Hardcoded in Amplify
      * It will always be da2-fakeApiId123456


### PR DESCRIPTION
# Description

This PR checks the ENV vars for `GraphQLAPIEndpointOutput` and if it finds it uses it instead of the fallback setting.

Necessary as the graphql endpoint set in my mocked environment differed from the default set here