### PR TITLE
Fix unmatched db field names in queries

### DIFF
--- a/handlers/whitelist.js
+++ b/handlers/whitelist.js
@@ -1,8 +1,8 @@
 const { poorMansGraphQL } = require('../utils');
 
 function handleUserStatusCreate(user, whitelistAddress, status = null, agreement = null) {
-  const input = status ? `{ walletAddress: "${user}", approved: ${Boolean(status)}, whitelistID: "${whitelistAddress}" }` :
-  `{ walletAddress: "${user}", agreementSigned: true, whitelistID: "${whitelistAddress}" }`
+  const input = status ? `{ walletAddress: "${user}", approved: ${Boolean(status)}, whitelistId: "${whitelistAddress}" }` :
+  `{ walletAddress: "${user}", agreementSigned: true, whitelistId: "${whitelistAddress}" }`
   const query = {
     operationName: "CreateUserStatusMutation",
     query: `
@@ -47,7 +47,7 @@ async function handleUserApproved(args, whitelistAddress) {
     query: `
         query UserStatusByWhitelistAndWalletAddress {
           userStatusByWhitelistAndWalletAddress(
-          whitelistID: "${whitelistAddress}",
+          whitelistId: "${whitelistAddress}",
           walletAddress: {eq: "${_user}"}
         ) {
           items {
@@ -81,7 +81,7 @@ async function handleAgreementSigned(args, whitelistAddress) {
     query: `
         query UserStatusByWhitelistAndWalletAddress {
           userStatusByWhitelistAndWalletAddress(
-          whitelistID: "${whitelistAddress}",
+          whitelistId: "${whitelistAddress}",
           walletAddress: {eq: "${_user}"}
         ) {
           items {


### PR DESCRIPTION
# Description 

This PR fixes the mis-match in field names that the graphql queries are making due to an earlier change that unified how the frontend and the db named these variables