### PR TITLE
Expand order history to include Period

### DIFF
--- a/handlers/coinMachine.js
+++ b/handlers/coinMachine.js
@@ -125,12 +125,19 @@ async function handleTokensBought(args, coinMachineAddress) {
     const { buyer, numTokens, totalCost } = args;
     const tokens = ethers.utils.formatUnits(numTokens, tokenDecimals);
     const cost = ethers.utils.formatUnits(totalCost, purchaseTokenDecimals);
+    const currentPeriod = await contract.getCurrentPeriod();
     const query = {
       operationName: "CreateOrdersHistory",
       query: `
           mutation CreateOrdersHistory {
             createOrdersHistory(
-            input: { coinMachineAddress: "${coinMachineAddress}", walletAddress: "${buyer}", volume: "${tokens}", marketPrice: "${parseFloat(cost/tokens)}" }
+            input: {
+              coinMachineAddress: "${coinMachineAddress}",
+              walletAddress: "${buyer}",
+              volume: "${tokens}",
+              marketPrice: "${parseFloat(cost / tokens)}",
+              period: ${currentPeriod.toNumber()}
+            }
             condition: {}
           ) {
             id


### PR DESCRIPTION
# Description

This PR expands the entries in the order history to include the period in which the orders were made. 
This is used in the main coinmachine UI for a variety of purposes see: https://github.com/JoinColony/coinMachine/pull/339