### PR TITLE
Update sale object with chain data

### DIFF
--- a/handlers/coinMachine.js
+++ b/handlers/coinMachine.js
@@ -110,6 +110,7 @@ async function handleTokensBought(args, coinMachineAddress, contract) {
             purchaseToken
             id
             endDate
+            userCount
             users(filter: {userID: {eq: "${buyer}"}}) {
               items {
                 userID
@@ -129,7 +130,7 @@ async function handleTokensBought(args, coinMachineAddress, contract) {
     if (!sale) return [];
 
     // Create Order History Entry
-    const { tokenDecimals, purchaseToken, id, endDate } = sale;
+    const { tokenDecimals, purchaseToken, id, endDate, userCount } = sale;
     const purchaseTokenDecimals = purchaseTokens.find(
       (token) => token.tokenAddress === purchaseToken
     )?.decimals;
@@ -158,6 +159,8 @@ async function handleTokensBought(args, coinMachineAddress, contract) {
     };
 
     // Update Sale Information
+    const firstTimeBuy = sale.users.items.length === 0;
+
     const [totalSold, totalIntake, tokenBalance, intakeCap] = await Promise.all(
       [
         contract.getSoldTotal(),
@@ -185,6 +188,7 @@ async function handleTokensBought(args, coinMachineAddress, contract) {
             totalSold: "${formattedSold}",
             totalIntake: "${formattedIntake}",
             endDate: ${updatedEndDate}
+            userCount: ${firstTimeBuy ? userCount + 1 : userCount}
           }
           condition: {}
         ) {
@@ -196,8 +200,6 @@ async function handleTokensBought(args, coinMachineAddress, contract) {
     };
 
     const queries = [query, saleUpdateQuery];
-
-    const firstTimeBuy = sale.users.items.length === 0;
 
     if (firstTimeBuy) {
       // Create User Sale Connection

--- a/index.js
+++ b/index.js
@@ -94,11 +94,11 @@ const subsribeToCoinMachine = async (coinMachineAddress, provider) => {
     const contract = await new ethers.Contract(coinMachineAddress, coinMachine.abi, provider);
     contract.on('*', async(event) => {
       const parsed = contract.interface.parseLog(event);
-      const handler =  CoinMachineEvents[event.event];
+      const handler = CoinMachineEvents[event.event];
       if (!handler) return;
-      const query = await handler(parsed.args, coinMachineAddress, contract);
+      const queries = await handler(parsed.args, coinMachineAddress, contract);
       try {
-        await poorMansGraphQL(query);
+        Promise.all(queries.map((query) => poorMansGraphQL(query)));
         output(`Database updated after event: ${event.event}`);
       } catch (error) {
         console.log(error);


### PR DESCRIPTION
# Description

This PR extends the `handleTokensBought` handler to update the sale object with blockchain data points `totalSold`, `totalIntake` and if the sale is sold out via either tokens or max intake it updates the sale `soldOut` which can be subscribed to in the UI. 