### PR TITLE
Set correct ownership when creating db objects with graphql

### DIFF
--- a/handlers/whitelist.js
+++ b/handlers/whitelist.js
@@ -6,11 +6,12 @@ function handleUserStatusCreate(
   status = null,
   agreement = null
 ) {
-  const input = status
-    ? `{ walletAddress: "${user}", approved: ${Boolean(
-        status
-      )}, whitelistId: "${whitelistAddress}" }`
-    : `{ walletAddress: "${user}", agreementSigned: true, whitelistId: "${whitelistAddress}" }`;
+  const input = `{
+          owner: "${user}"
+          walletAddress: "${user}",
+          whitelistId: "${whitelistAddress}",
+          ${status ? `approved: ${Boolean(status)}` : `agreementSigned: true`}
+       }`;
   const query = {
     operationName: "CreateUserStatusMutation",
     query: `

--- a/index.js
+++ b/index.js
@@ -168,7 +168,12 @@ const subsribeToCoinMachine = async (coinMachineAddress, provider) => {
           query: `
               mutation CreateCompanyAgreement {
                 createCompanyAgreement(
-                input: { coinMachineAddress: "${coinMachine}", userCompanyAgreementsId: "${owner}", agreementHash: "${agreementHash}" }
+                input: {
+                  coinMachineAddress: "${coinMachine}",
+                  userCompanyAgreementsId: "${owner}",
+                  agreementHash: "${agreementHash}",
+                  owner: "${owner}"
+                }
               ) {
                 coinMachineAddress
               }


### PR DESCRIPTION
# Description

This PR sets the correct ownership for db objects when they are created via the block ingestor so that they can be updated later by the user it has been created for. 