### PR TITLE
Correctly update coinmachine status

### DIFF
--- a/handlers/coinMachine.js
+++ b/handlers/coinMachine.js
@@ -46,9 +46,10 @@ async function handleCoinMachineInitialised(args, coinMachineAddress) {
 }
 
 const CoinMachineStatus = {
-  0: "ACTIVE",
-  1: "PAUSED",
-  2: "STOPPED",
+  0: "INACTIVE",
+  1: "ACTIVE",
+  2: "PAUSED",
+  3: "STOPPED",
 };
 
 async function handleCoinMachineStateSet(args, coinMachineAddress) {


### PR DESCRIPTION
# Description 

This PR correctly updates the coinmachine status by fixing the off by one error caused by the incorrect listing of all the possible states for coinmachine to be in
